### PR TITLE
replace shebang lines with more portable versions.

### DIFF
--- a/bin/rsprof-filter
+++ b/bin/rsprof-filter
@@ -1,0 +1,183 @@
+#!/usr/bin/perl
+
+$| = 1;
+
+use strict;
+use warnings;
+
+use JSON::Syck;
+use Getopt::Long;
+
+my $path_field = "path";
+my %time_fields = ();
+my %call_fields = ();
+my @filters;
+
+GetOptions(
+    "path-field=s" => \$path_field,
+    "time-field=s" => sub { for my $field (split(/,/, $_[1])) { $time_fields{$field} = 1; } },
+    "call-field=s" => sub { for my $field (split(/,/, $_[1])) { $call_fields{$field} = 1; } },
+    "compact-frame=s" => sub { push @filters, compact_frame_filter($_[1]); },
+    "compact-before=s" => sub { push @filters, compact_before_filter($_[1]); },
+    "compact-beyond=s" => sub { push @filters, compact_beyond_filter($_[1]); },
+) || die;
+
+sub make_regex {
+    my $match = shift;
+    my $demand_front = shift;
+    my $demand_back = shift;
+
+    my $front = ($demand_front ? ".*/" : "(?:.*/)?");
+    my $back = ($demand_back ? "/.*" : "(?:/.*)?");
+
+    if($match =~ /^\/(.*)\/$/) {
+        return qr/^($front)($1)($back)$/;
+    }
+    else {
+        return qr/^($front)(\Q$match\E)($back)$/;
+    }
+}
+
+sub compact_frame_filter {
+    my $match = shift;
+
+    my $re = make_regex($match, 0, 0);
+
+    # X/FRAME/Y, t, c => X/Y, t, c
+    # X/FRAME, t, c => X, t, 0
+    # ELSE, t, c => ELSE, t, c
+    return sub {
+        my $path = shift;
+
+        my $keep_c = 1;
+        while($path =~ $re) {
+            my $pre = $1;
+            my $post = $3;
+            if($post eq "") {
+                $keep_c = 0;
+            }
+            $path = "$pre$post";
+        }
+
+        return ($path, $keep_c);
+    };
+}
+
+sub compact_before_filter {
+    my $match = shift;
+
+    my $soft_re = make_regex($match, 0, 0);
+    my $hard_re = make_regex($match, 1, 0);
+
+    # X/BEFORE/Y, t, c => BEFORE/Y, t, c
+    # X/BEFORE, t, c => BEFORE, t, c
+    # ELSE => <drop>
+    return sub {
+        my $path = shift;
+
+        if($path !~ $soft_re) {
+            return undef;
+        }
+
+        while($path =~ $hard_re) {
+            my $middle = $2;
+            my $post = $3;
+            $path = "$middle$post";
+        }
+
+        return ($path, 1);
+    };
+}
+
+sub compact_beyond_filter {
+    my $match = shift;
+
+    my $hard_re = make_regex($match, 0, 1);
+
+    # X/BEYOND/Y, t, c => X/BEYOND, t, 0
+    # X/BEYOND, t, c => X/BEYOND, t, c
+    # ELSE, t, c => ELSE, t, c
+    return sub {
+        my $path = shift;
+
+        my $keep_c = 1;
+        while($path =~ $hard_re) {
+            my $pre = $1;
+            my $middle = $2;
+            $path = "$pre$middle";
+            $keep_c = 0;
+        }
+
+        return ($path, $keep_c);
+    };
+}
+
+{
+    my $output = new_output();
+
+    while(<>) {
+        chomp;
+        my $r = JSON::Syck::Load($_);
+        my $path = $r->{$path_field};
+
+        my $keep_c = 1;
+        for my $filter (@filters) {
+            if(!defined($path)) {
+                last;
+            }
+
+            my ($path2, $keep_c2) = $filter->($path);
+            $path = $path2;
+            if(!$keep_c2) {
+                $keep_c = 0;
+            }
+        }
+
+        if(!defined($path)) {
+            next;
+        }
+
+        for my $field (keys(%time_fields)) {
+            my $value = $r->{$field};
+            if(defined($value)) {
+                push_output($output, $path, $field, $value);
+            }
+        }
+
+        for my $field (keys(%call_fields)) {
+            my $value = $r->{$field};
+            if(defined($value)) {
+                if(!$keep_c) {
+                    $value = 0;
+                }
+                push_output($output, $path, $field, $value);
+            }
+        }
+    }
+
+    for my $entry (@{$output->[1]}) {
+        my $path = $entry->[0];
+        my $fields = $entry->[1];
+        print JSON::Syck::Dump({$path_field => $path, %$fields}) . "\n";
+    }
+}
+
+sub new_output {
+    return [{}, []];
+}
+
+sub push_output {
+    my $output = shift;
+    my $path = shift;
+    my $field = shift;
+    my $value = shift;
+
+    my $outputh = $output->[0];
+    my $outputa = $output->[1];
+    my $entry = $outputh->{$path};
+    if(!$entry) {
+        push @$outputa, ($outputh->{$path} = $entry = [$path, {}]);
+    }
+
+    ($entry->[1]->{$field} ||= 0) += $value;
+}

--- a/bin/rsprof-filter
+++ b/bin/rsprof-filter
@@ -64,6 +64,11 @@ sub compact_frame_filter {
             $path =~ s/\/$//;
         }
 
+        # TODO: zOMG, terrible
+        if($path eq '') {
+            return undef;
+        }
+
         return ($path, $keep_c);
     };
 }

--- a/bin/rsprof-filter
+++ b/bin/rsprof-filter
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $| = 1;
 

--- a/bin/rsprof-filter
+++ b/bin/rsprof-filter
@@ -5,8 +5,13 @@ $| = 1;
 use strict;
 use warnings;
 
-use JSON::Syck;
 use Getopt::Long;
+use JSON qw(decode_json);
+
+my $json = JSON::XS->new();
+$json->allow_nonref(1);
+$json->allow_blessed(1);
+$json->convert_blessed(1);
 
 my $path_field = "path";
 my %time_fields = ();
@@ -129,7 +134,7 @@ sub compact_beyond_filter {
 
     while(<>) {
         chomp;
-        my $r = JSON::Syck::Load($_);
+        my $r = decode_json($_);
         my $path = $r->{$path_field};
 
         my $keep_c = 1;
@@ -170,7 +175,7 @@ sub compact_beyond_filter {
     for my $entry (@{$output->[1]}) {
         my $path = $entry->[0];
         my $fields = $entry->[1];
-        print JSON::Syck::Dump({$path_field => $path, %$fields}) . "\n";
+        print $json->encode({$path_field => $path, %$fields}) . "\n";
     }
 }
 

--- a/bin/rsprof-filter
+++ b/bin/rsprof-filter
@@ -57,6 +57,10 @@ sub compact_frame_filter {
                 $keep_c = 0;
             }
             $path = "$pre$post";
+            # TODO: omfg, think of a better way to do this
+            $path =~ s/\/\/*/\//g;
+            $path =~ s/^\///;
+            $path =~ s/\/$//;
         }
 
         return ($path, $keep_c);

--- a/bin/rsprof-filter
+++ b/bin/rsprof-filter
@@ -31,10 +31,10 @@ sub make_regex {
     my $back = ($demand_back ? "/.*" : "(?:/.*)?");
 
     if($match =~ /^\/(.*)\/$/) {
-        return qr/^($front)($1)($back)$/;
+        return qr/^(?<pre>$front)(?<middle>$1)(?<post>$back)$/;
     }
     else {
-        return qr/^($front)(\Q$match\E)($back)$/;
+        return qr/^(?<pre>$front)(?<middle>\Q$match\E)(?<post>$back)$/;
     }
 }
 
@@ -51,8 +51,9 @@ sub compact_frame_filter {
 
         my $keep_c = 1;
         while($path =~ $re) {
-            my $pre = $1;
-            my $post = $3;
+            my $pre = $+{'pre'};
+            my $middle = $+{'middle'};
+            my $post = $+{'post'};
             if($post eq "") {
                 $keep_c = 0;
             }
@@ -84,8 +85,9 @@ sub compact_before_filter {
         }
 
         while($path =~ $hard_re) {
-            my $middle = $2;
-            my $post = $3;
+            my $pre = $+{'pre'};
+            my $middle = $+{'middle'};
+            my $post = $+{'post'};
             $path = "$middle$post";
         }
 
@@ -106,8 +108,9 @@ sub compact_beyond_filter {
 
         my $keep_c = 1;
         while($path =~ $hard_re) {
-            my $pre = $1;
-            my $middle = $2;
+            my $pre = $+{'pre'};
+            my $middle = $+{'middle'};
+            my $post = $+{'post'};
             $path = "$pre$middle";
             $keep_c = 0;
         }

--- a/bin/rsprof-from-jstack
+++ b/bin/rsprof-from-jstack
@@ -7,12 +7,12 @@ use warnings;
 
 use JSON::Syck;
 
-my $thread = undef;
+my $name = undef;
 my @stack;
 while(<>) {
     chomp;
     if(/^"(.*)"/) {
-        $thread = $1;
+        $name = $1;
     }
     if(/^	(.*)$/) {
         my $elt = $1;
@@ -35,11 +35,14 @@ while(<>) {
 flush();
 
 sub flush {
-    if(defined($thread)) {
+    if(defined($name)) {
         @stack = reverse @stack;
-        print JSON::Syck::Dump({'path' => \@stack, 'thread-name' => $thread}) . "\n";
-
-        $thread = undef;
+        my $r = {
+            'name' => $name,
+            'path' => join("/", @stack),
+        };
+        print JSON::Syck::Dump($r) . "\n";
         @stack = ();
+        $name = undef;
     }
 }

--- a/bin/rsprof-from-jstack
+++ b/bin/rsprof-from-jstack
@@ -7,12 +7,20 @@ use warnings;
 
 use JSON::Syck;
 
+my $time = undef;
 my $name = undef;
+my $state = undef;
 my @stack;
 while(<>) {
     chomp;
+    if(/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d$/) {
+        $time = $_;
+    }
     if(/^"(.*)"/) {
         $name = $1;
+    }
+    if(/^ *[^ ]*Thread\.State: ([^ ]*)/) {
+        $state = $1;
     }
     if(/^	(.*)$/) {
         my $elt = $1;
@@ -21,7 +29,7 @@ while(<>) {
             my $meth = $1;
             my $src = $2;
 
-            if($src =~ /:([0-9+])$/) {
+            if($src =~ /:([0-9]+)$/) {
                 $meth = "$meth:L$1";
             }
 
@@ -38,7 +46,9 @@ sub flush {
     if(defined($name)) {
         @stack = reverse @stack;
         my $r = {
+            'time' => $time,
             'name' => $name,
+            'state' => $state,
             'path' => join("/", @stack),
         };
         print JSON::Syck::Dump($r) . "\n";

--- a/bin/rsprof-from-jstack
+++ b/bin/rsprof-from-jstack
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $| = 1;
 

--- a/bin/rsprof-from-jstack
+++ b/bin/rsprof-from-jstack
@@ -13,6 +13,10 @@ my $state = undef;
 my @stack;
 while(<>) {
     chomp;
+
+    # tolerate certain whitespace damage
+    s/\s*$//;
+
     if(/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d$/) {
         $time = $_;
     }
@@ -35,6 +39,13 @@ while(<>) {
 
             push @stack, $meth;
         }
+    }
+    # broke-ass formatting of proguard deobfuscator
+    if(/^     +([a-zA-Z]*)$/) {
+        my $alt = $1;
+        my $elt = pop @stack;
+        $elt =~ s/((?::L[0-9]*)?)$/|$alt$1/;
+        push @stack, $elt;
     }
     if(/^$/) {
         flush();

--- a/bin/rsprof-from-jstack
+++ b/bin/rsprof-from-jstack
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+$| = 1;
+
+use strict;
+use warnings;
+
+use JSON::Syck;
+
+my $thread = undef;
+my @stack;
+while(<>) {
+    chomp;
+    if(/^"(.*)"/) {
+        $thread = $1;
+    }
+    if(/^	(.*)$/) {
+        my $elt = $1;
+        if($elt =~ /at (.*)\((.*)\)/)
+        {
+            my $meth = $1;
+            my $src = $2;
+
+            if($src =~ /:([0-9+])$/) {
+                $meth = "$meth:L$1";
+            }
+
+            push @stack, $meth;
+        }
+    }
+    if(/^$/) {
+        flush();
+    }
+}
+flush();
+
+sub flush {
+    if(defined($thread)) {
+        @stack = reverse @stack;
+        print JSON::Syck::Dump({'path' => \@stack, 'thread-name' => $thread}) . "\n";
+
+        $thread = undef;
+        @stack = ();
+    }
+}

--- a/bin/rsprof-from-jstack
+++ b/bin/rsprof-from-jstack
@@ -5,7 +5,12 @@ $| = 1;
 use strict;
 use warnings;
 
-use JSON::Syck;
+use JSON;
+
+my $json = JSON::XS->new();
+$json->allow_nonref(1);
+$json->allow_blessed(1);
+$json->convert_blessed(1);
 
 my $time = undef;
 my $name = undef;
@@ -62,7 +67,7 @@ sub flush {
             'state' => $state,
             'path' => join("/", @stack),
         };
-        print JSON::Syck::Dump($r) . "\n";
+        print $json->encode($r) . "\n";
         @stack = ();
         $name = undef;
     }

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -14,6 +14,8 @@ my $order = \&order_file;
 my $path_field = "path";
 my $time_field = undef;
 my $min_time = undef;
+my $min_perc = undef;
+my $min_rel_perc = undef;
 my $call_field = undef;
 my $blank = 0;
 my $acc = 0;
@@ -25,6 +27,8 @@ GetOptions(
     "path-field=s" => \$path_field,
     "time-field=s" => \$time_field,
     "min-time=s" => \$min_time,
+    "min-perc=s" => \$min_perc,
+    "min-rel-perc=s" => \$min_rel_perc,
     "call-field=s" => \$call_field,
     "accumulate!" => \$acc,
     "blank!" => \$blank,
@@ -89,6 +93,9 @@ sub format_key {
     if(defined($min_time) && $time < $min_time) {
         return;
     }
+    if(defined($min_perc) && $time / $total * 100 < $min_perc) {
+        return;
+    }
 
     my @r;
     if(defined($time_field)) {
@@ -116,13 +123,20 @@ sub dump_tree {
     my ($tree, @stack) = @_;
 
     my $key = join("/", @stack);
-    if($times->{$key}) {
+    if(defined($times->{$key})) {
         format_key($key);
     }
 
     my @options = @{$tree->[0]};
     @options = $order->(\@stack, @options);
     for my $s (@options) {
+        if(defined($min_rel_perc)) {
+            my $time = ($times->{$key} || 0);
+            my $time2 = $times->{join("/", @stack, $s)} || 0;
+            if($time2 / $time * 100 < $min_rel_perc) {
+                next;
+            }
+        }
         dump_tree($tree->[1]->{$s}, @stack, $s);
     }
 }

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -130,6 +130,6 @@ sub order_lex {
 }
 
 sub order_time {
-    my $stack = join("/", shift);
-    return sort { (($times->{"$stack/$b"} || 0) <=> ($times->{"$stack/$a"} || 0)) || ($a cmp $b) } @_;
+    my $stack = shift;
+    return sort { (($times->{join(@$stack, $b)} || 0) <=> ($times->{join(@$stack, $a)} || 0)) || ($a cmp $b) } @_;
 }

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -5,6 +5,8 @@ $| = 1;
 use strict;
 use warnings;
 
+no warnings ('recursion');
+
 use JSON::Syck;
 use Getopt::Long;
 

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -133,7 +133,7 @@ sub dump_tree {
         if(defined($min_rel_perc)) {
             my $time = ($times->{$key} || 0);
             my $time2 = $times->{join("/", @stack, $s)} || 0;
-            if($time2 / $time * 100 < $min_rel_perc) {
+            if($time2 * 100 < $min_rel_perc * $time) {
                 next;
             }
         }

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -113,10 +113,22 @@ sub format_key {
         }
     }
 
-    my $r0 = shift @r;
-    my $r1 = @r ? (" (" . join(", ", @r) . ")") : "";
+    my $r;
+    if(@r)
+    {
+        $r = shift @r;
+        if(@r)
+        {
+            $r .= " (" . join(", ", @r) . ")";
+        }
+    }
+    else
+    {
+        # no measures, oops!
+        $r = "?";
+    }
 
-    print "$key => $r0$r1\n";
+    print "$key => $r\n";
 }
 
 sub dump_tree {

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $| = 1;
 

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -7,7 +7,7 @@ use warnings;
 
 no warnings ('recursion');
 
-use JSON::Syck;
+use JSON qw(decode_json);
 use Getopt::Long;
 
 my $order = \&order_file;
@@ -41,7 +41,7 @@ my $total = 0;
 
 while(<>) {
     chomp;
-    my $r = JSON::Syck::Load($_);
+    my $r = decode_json($_);
     my $path = $r->{$path_field};
     next unless(defined($path));
     my $time = defined($time_field) ? ($r->{$time_field} || 0) : 0;

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -11,6 +11,7 @@ use Getopt::Long;
 my $order = \&order_file;
 my $path_field = "path";
 my $time_field = undef;
+my $min_time = undef;
 my $call_field = undef;
 my $blank = 0;
 my $acc = 0;
@@ -21,6 +22,7 @@ GetOptions(
     "order-time!" => sub { $order = \&order_time; },
     "path-field=s" => \$path_field,
     "time-field=s" => \$time_field,
+    "min-time=s" => \$min_time,
     "call-field=s" => \$call_field,
     "accumulate!" => \$acc,
     "blank!" => \$blank,
@@ -81,6 +83,10 @@ sub format_key {
 
     my $time = $times->{$key} || 0;
     my $call = $calls->{$key} || 0;
+
+    if(defined($min_time) && $time < $min_time) {
+        return;
+    }
 
     my @r;
     if(defined($time_field)) {

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -139,5 +139,5 @@ sub order_lex {
 
 sub order_time {
     my $stack = shift;
-    return sort { (($times->{join(@$stack, $b)} || 0) <=> ($times->{join(@$stack, $a)} || 0)) || ($a cmp $b) } @_;
+    return sort { (($times->{join("/", @$stack, $b)} || 0) <=> ($times->{join("/", @$stack, $a)} || 0)) || ($a cmp $b) } @_;
 }

--- a/bin/rsprof-report-tree
+++ b/bin/rsprof-report-tree
@@ -1,0 +1,135 @@
+#!/usr/bin/perl
+
+$| = 1;
+
+use strict;
+use warnings;
+
+use JSON::Syck;
+use Getopt::Long;
+
+my $order = \&order_file;
+my $path_field = "path";
+my $time_field = undef;
+my $call_field = undef;
+my $blank = 0;
+my $acc = 0;
+
+GetOptions(
+    "order-file!" => sub { $order = \&order_file; },
+    "order-lex!" => sub { $order = \&order_lex; },
+    "order-time!" => sub { $order = \&order_time; },
+    "path-field=s" => \$path_field,
+    "time-field=s" => \$time_field,
+    "call-field=s" => \$call_field,
+    "accumulate!" => \$acc,
+    "blank!" => \$blank,
+) || die;
+
+my $times = {};
+my $calls = {};
+my $tree = [[], {}];
+my $total = 0;
+
+while(<>) {
+    chomp;
+    my $r = JSON::Syck::Load($_);
+    my $path = $r->{$path_field};
+    next unless(defined($path));
+    my $time = defined($time_field) ? ($r->{$time_field} || 0) : 0;
+    my $call = defined($call_field) ? ($r->{$call_field} || 0) : 0;
+
+    my @stack = split(/\//, $path);
+    add_tree($tree, @stack);
+    {
+        my @stackt = @stack;
+        while(1) {
+            charge($call, $time, @stackt);
+            pop @stackt;
+            last unless($acc && @stackt);
+            $call = 0;
+        }
+    }
+    $total += $time;
+}
+
+dump_tree($tree);
+
+sub charge {
+    my ($delta_call, $delta_time, @stack) = @_;
+
+    my $key = join("/", @stack);
+    ($times->{$key} ||= 0) += $delta_time;
+    ($calls->{$key} ||= 0) += $delta_call;
+}
+
+sub add_tree {
+    my ($tree, @stack) = @_;
+    while(@stack) {
+        my $s = shift @stack;
+        my $tree2 = $tree->[1]->{$s};
+        if(!$tree2) {
+            $tree2 = $tree->[1]->{$s} = [[], {}];
+            push @{$tree->[0]}, $s;
+        }
+        $tree = $tree2;
+    }
+}
+
+sub format_key {
+    my ($key) = @_;
+
+    my $time = $times->{$key} || 0;
+    my $call = $calls->{$key} || 0;
+
+    my @r;
+    if(defined($time_field)) {
+        push @r, sprintf("%d [%0.04f%%]", $time, $time / $total * 100);
+    }
+    if(defined($call_field)) {
+        push @r, $call;
+    }
+    if(defined($time_field) && defined($call_field)) {
+        push @r, ($call ? ($time / $call) : "N/A");
+    }
+
+    if($blank) {
+        while($key =~ s/^( *)[^\/]*\//$1   /) {
+        }
+    }
+
+    my $r0 = shift @r;
+    my $r1 = @r ? (" (" . join(", ", @r) . ")") : "";
+
+    print "$key => $r0$r1\n";
+}
+
+sub dump_tree {
+    my ($tree, @stack) = @_;
+
+    my $key = join("/", @stack);
+    if($times->{$key}) {
+        format_key($key);
+    }
+
+    my @options = @{$tree->[0]};
+    @options = $order->(\@stack, @options);
+    for my $s (@options) {
+        dump_tree($tree->[1]->{$s}, @stack, $s);
+    }
+}
+
+sub order_file {
+    my $stack = shift;
+    return @_;
+}
+
+sub order_lex {
+    my $stack = shift;
+    return sort { $a cmp $b } @_;
+}
+
+sub order_time {
+    my $stack = join("/", shift);
+    return sort { (($times->{"$stack/$b"} || 0) <=> ($times->{"$stack/$a"} || 0)) || ($a cmp $b) } @_;
+}


### PR DESCRIPTION
I tried to run rsprof inside a docker container based on a standard docker perl image, but it puts a more recent perl in /usr/local so rsprof can't find things like JSON.pm on the module path.
